### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ Deploy ECS service to a Docker image.
 
 ## Install
 
-[Download the binary](https://github.com/travisjeffery/ecs-deploy/releases/latest), or go get:
-
 ```
-$ go get github.com/travisjeffery/ecs-deploy
+$ go get github.com/gametimesf/ecs-deploy
 ```
 
 ## Example


### PR DESCRIPTION
This is a fork of `github.com/travisjeffery/ecs-deploy` and the README still references that repo in the `go get` command. Updated to reference our forked version.