### PR TITLE
Be 11934

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -42,12 +42,13 @@ func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error
 		}
 	}
 	input := &ecs.RegisterTaskDefinitionInput{
-		Family:               task,
-		TaskRoleArn:          taskDef.TaskRoleArn,
-		NetworkMode:          taskDef.NetworkMode,
-		ContainerDefinitions: defs,
-		Volumes:              taskDef.Volumes,
-		PlacementConstraints: taskDef.PlacementConstraints,
+		Family:                  task,
+		TaskRoleArn:             taskDef.TaskRoleArn,
+		NetworkMode:             taskDef.NetworkMode,
+		ContainerDefinitions:    defs,
+		Volumes:                 taskDef.Volumes,
+		PlacementConstraints:    taskDef.PlacementConstraints,
+		RequiresCompatibilities: taskDef.RequiresCompatibilities,
 	}
 	resp, err := c.svc.RegisterTaskDefinition(input)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -49,6 +49,7 @@ func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error
 		Volumes:                 taskDef.Volumes,
 		PlacementConstraints:    taskDef.PlacementConstraints,
 		RequiresCompatibilities: taskDef.RequiresCompatibilities,
+		ExecutionRoleArn:        taskDef.ExecutionRoleArn,
 	}
 	resp, err := c.svc.RegisterTaskDefinition(input)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -51,6 +51,7 @@ func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error
 		RequiresCompatibilities: taskDef.RequiresCompatibilities,
 		ExecutionRoleArn:        taskDef.ExecutionRoleArn,
 		Cpu:                     taskDef.Cpu,
+		Memory:                  taskDef.Memory,
 	}
 	resp, err := c.svc.RegisterTaskDefinition(input)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -50,6 +50,7 @@ func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error
 		PlacementConstraints:    taskDef.PlacementConstraints,
 		RequiresCompatibilities: taskDef.RequiresCompatibilities,
 		ExecutionRoleArn:        taskDef.ExecutionRoleArn,
+		Cpu:                     taskDef.Cpu,
 	}
 	resp, err := c.svc.RegisterTaskDefinition(input)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/gametimesf/ecs-deploy
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.10.41
+	github.com/aws/aws-sdk-go v1.55.2
 	github.com/go-ini/ini v1.28.2 // indirect
-	github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.10.41 h1:UyVBOtDEac826hNYfu2F3A8kpJ0f5puT7PvfJikxGS4=
 github.com/aws/aws-sdk-go v1.10.41/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/aws/aws-sdk-go v1.55.2 h1:/2OFM8uFfK9e+cqHTw9YPrvTzIXT2XkFGXRM7WbJb7E=
+github.com/aws/aws-sdk-go v1.55.2/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ini/ini v1.28.2 h1:drmmYv7psRpoGZkPtPKKTB+ZFSnvmwCMfNj5o1nLh2Y=
@@ -8,6 +10,9 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9 h1:1SlajWtS+u/6x2Be5vrHyrbSxkeIf/+ISBu//kmjpnc=
 github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -27,3 +32,5 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description
A new [Fargate cluster](https://us-west-2.console.aws.amazon.com/ecs/v2/clusters/testing-internal-compute-cluster/services?region=us-west-2) has been created to host the-algo-pvt but when the-algo-pvt is depoyed it results in an [error](https://github.com/gametimesf/the-algo/actions/runs/10081370397/job/27881290090) .  

this error occurs because when registering a new version of a task ecs-deploy creates an input struct that contains properties of the current version.  It looks like the current input doesn't copy over every field of the existing task.  As a result the deployment fails.   



## This is how I decided to implement/fix it
To address this, the version of [aws-sdk-go ](https://github.com/aws/aws-sdk-go) was needed because it has some additional fields that are not available in the current version used by ecs-deploy.  

After updating the version, additional fields were added to the input until the deployment succeeded.

## JIRA link
https://gametime.atlassian.net/browse/BE-11934
## What does this change affect? (What can this break?)
Since ecs-deploy is used for deployments in many repos, this would potentially impact them.  

## How has this been tested

1. created a branch of github-actions-go and pointed that branch to this version of ecs-deploy (https://github.com/gametimesf/github-actions-go/blob/be-11936/.github/workflows/deploy.yaml#L112)
2. updated build-and-deploy.yaml in the-algo to point to branch version of github-actions-go (https://github.com/gametimesf/the-algo/blob/testing/.github/workflows/build-and-deploy.yml#L25, https://github.com/gametimesf/the-algo/blob/testing/.github/workflows/build-and-deploy.yml#L37, https://github.com/gametimesf/the-algo/blob/testing/.github/workflows/build-and-deploy.yml#L50) for the-algo, the-algo-pvt, and new new job the-algo-pvt compute
3. deploy job succeeded https://github.com/gametimesf/the-algo/actions/runs/10104988172
4. verified all 3 services work (curl "https://algo.testing.gteng.co/v1/event/5f171b295927cf000136a551/all", curl "https://algo-private.testing.gteng.co/v1/event/5f171b295927cf000136a551/all", curl "https://algo-private-compute.testing.gteng.co/v1/event/5f171b295927cf000136a551/all")
## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored
