### PR TITLE
feat: add tagging options for ECS services

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ usage: ecs-deploy --service=SERVICE [<flags>]
 Deploy ECS service.
 
 Flags:
-  --help                Show context-sensitive help (also try --help-long and --help-man).
-  --service=SERVICE     Name of Service to update.
-  --task=TASK-DEF       Name of Task Definition to update. Defaults to service.
-  --image=IMAGE         Name of Docker image to run.
-  --tag=TAG             Tag of Docker image to run.
-  --cluster="default"   Name of ECS cluster.
-  --region="us-east-1"  Name of AWS region.
-  --count=-1            Desired count of instantiations to run. Defaults to existing running count.
-  --nowait              Disable waiting for task definitions to start running.
-  --version             Show application version.
+  --help                            Show context-sensitive help (also try --help-long and --help-man).
+  --service=SERVICE                 Name of Service to update.
+  --task=TASK-DEF                   Name of Task Definition to update. Defaults to service.
+  --image=IMAGE                     Name of Docker image to run.
+  --tag=TAG                         Tag of Docker image to run.
+  --cluster="default"               Name of ECS cluster.
+  --region="us-east-1"              Name of AWS region.
+  --count=-1                        Desired count of instantiations to run. Defaults to existing running count.
+  --nowait                          Disable waiting for task definitions to start running.
+  --version                         Show application version.
+  --enable-ecs-managed-tags=false   Enable adding ECS managed tags to tasks.
+  --propagate-tags="NONE"           Enable adding custom tags to tasks. Options indicate source: TASK_DEFINITION, SERVICE, NONE
 ```
 
 You can also override the default region by setting the `AWS_DEFAULT_REGION` environmental variable.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Flags:
   --count=-1                        Desired count of instantiations to run. Defaults to existing running count.
   --nowait                          Disable waiting for task definitions to start running.
   --version                         Show application version.
-  --enable-ecs-managed-tags=false   Enable adding ECS managed tags to tasks.
+  --enable-ecs-managed-tags=true    Enable adding ECS managed tags to tasks.
   --propagate-tags="NONE"           Enable adding custom tags to tasks. Options indicate source: TASK_DEFINITION, SERVICE, NONE
 ```
 

--- a/client/client.go
+++ b/client/client.go
@@ -61,7 +61,7 @@ func (c *Client) RegisterTaskDefinition(task, image, tag *string) (string, error
 }
 
 // UpdateService updates the service to use the new task definition.
-func (c *Client) UpdateService(cluster, service *string, count *int64, arn *string) error {
+func (c *Client) UpdateService(cluster, service *string, count *int64, arn *string, enableECSManagedTags *bool, propagateTags *string) error {
 	input := &ecs.UpdateServiceInput{
 		Cluster: cluster,
 		Service: service,
@@ -71,6 +71,12 @@ func (c *Client) UpdateService(cluster, service *string, count *int64, arn *stri
 	}
 	if arn != nil {
 		input.TaskDefinition = arn
+	}
+	if enableECSManagedTags != nil {
+		input.EnableECSManagedTags = enableECSManagedTags
+	}
+	if propagateTags != nil {
+		input.PropagateTags = propagateTags
 	}
 	_, err := c.svc.UpdateService(input)
 	return err

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ var (
 	count                = flag.Int64("count", -1, "Desired count of instantiations to place and run in service. Defaults to existing running count.")
 	nowait               = flag.Bool("nowait", false, "Disable waiting for all task definitions to start running")
 	requireLatest        = flag.Bool("require-latest", true, "Require the latest task definition to be running")
-	enableECSManagedTags = flag.Bool("enable-ecs-managed-tags", false, "Enable ECS managed tags to be automatically added to running tasks.")
+	enableECSManagedTags = flag.Bool("enable-ecs-managed-tags", true, "Enable ECS managed tags to be automatically added to running tasks.")
 	propagateTags        = flag.String("propagate-tags", "NONE", "Propagate custom tags to the task. The value indicates the source of tags TASK_DEFINITION, SERVICE, or NONE.")
 )
 

--- a/main.go
+++ b/main.go
@@ -10,16 +10,27 @@ import (
 )
 
 var (
-	service       = flag.String("service", "", "Name of Service to update. Required.")
-	image         = flag.String("image", "", "Name of Docker image to run.")
-	tag           = flag.String("tag", "", "Tag of Docker image to run.")
-	cluster       = flag.String("cluster", "default", "Name of ECS cluster.")
-	task          = flag.String("task", "", "Name of task definition. Defaults to service name")
-	region        = flag.String("region", "us-east-1", "Name of AWS region.")
-	count         = flag.Int64("count", -1, "Desired count of instantiations to place and run in service. Defaults to existing running count.")
-	nowait        = flag.Bool("nowait", false, "Disable waiting for all task definitions to start running")
-	requireLatest = flag.Bool("require-latest", true, "Require the latest task definition to be running")
+	service              = flag.String("service", "", "Name of Service to update. Required.")
+	image                = flag.String("image", "", "Name of Docker image to run.")
+	tag                  = flag.String("tag", "", "Tag of Docker image to run.")
+	cluster              = flag.String("cluster", "default", "Name of ECS cluster.")
+	task                 = flag.String("task", "", "Name of task definition. Defaults to service name")
+	region               = flag.String("region", "us-east-1", "Name of AWS region.")
+	count                = flag.Int64("count", -1, "Desired count of instantiations to place and run in service. Defaults to existing running count.")
+	nowait               = flag.Bool("nowait", false, "Disable waiting for all task definitions to start running")
+	requireLatest        = flag.Bool("require-latest", true, "Require the latest task definition to be running")
+	enableECSManagedTags = flag.Bool("enable-ecs-managed-tags", false, "Enable ECS managed tags to be automatically added to running tasks.")
+	propagateTags        = flag.String("propagate-tags", "NONE", "Propagate custom tags to the task. The value indicates the source of tags TASK_DEFINITION, SERVICE, or NONE.")
 )
+
+func isValid(value string, validValues []string) bool {
+	for _, v := range validValues {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
 
 func main() {
 	flag.Parse()
@@ -37,6 +48,13 @@ func main() {
 	if *region == "" {
 		r := os.Getenv("AWS_DEFAULT_REGION")
 		region = &r
+	}
+
+	validPropagateTags := []string{"NONE", "TASK_DEFINITION", "SERVICE"}
+	if !isValid(*propagateTags, validPropagateTags) {
+		_, _ = fmt.Fprintln(os.Stderr, "propagate-tags must be one of NONE, TASK_DEFINITION, or SERVICE")
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	prefix := fmt.Sprintf("%s/%s ", *cluster, *service)
@@ -80,7 +98,7 @@ func main() {
 		}
 	}
 
-	err = c.UpdateService(cluster, service, count, &arn)
+	err = c.UpdateService(cluster, service, count, &arn, enableECSManagedTags, propagateTags)
 	if err != nil {
 		logger.Printf("[error] update service: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

### Feature/bug description:

ECS services have two settings that allow tasks to be tagged. The tags allow AWS cost data to have tags for finer grain cost analysis.

`enableECSManagedTags` This setting allows cluster and service tags to be automatically added to tasks.

`propagateTags` This setting allows custom tags that we add to be automatically added to tasks from either the service or task definition level. Any tags we set on the selected option will automatically be added to tasks.

### This is how I decided to implement/fix it:

Add options to enable ECS managed tags and propagate tags to tasks. Default `enableECSManagedTags` to enabled. Leave `propagateTags` disabled for now until we have a reason to enable it. 

By default these values are disabled. However a service is created (Terraform, manually, etc) deploying will enable the ECS managed tags.

Tags are added at task creation. So a deployment is required to enact settings changes. 

### JIRA link:

[PLT-568](https://gametime.atlassian.net/browse/PLT-568)

### What can this break:

No none breakages. It will expand costs reporting data output.

### How has this been tested:

I ran `ecs-deploy` with both options and without using `testing-platform-app-api` service. I got the expected results on the service and deployed task settings.

![image](https://github.com/user-attachments/assets/8755b918-b1f3-478f-8538-a28140b7b6ee)

Task showing ECS managed tags.

[PLT-568]: https://gametime.atlassian.net/browse/PLT-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ