### PR TITLE
refactor: use std lib for testing to avoid introducing toolchain dir

### DIFF
--- a/client/task_role_upgrade_test.go
+++ b/client/task_role_upgrade_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // MockIAMClient is a simple mock for the IAM client.
@@ -74,11 +72,19 @@ func TestExtractServiceInfo(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			name, env, err := extractServiceInfo(tc.input)
 			if tc.expectError {
-				require.Error(t, err)
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
 			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedName, name)
-				assert.Equal(t, tc.expectedEnv, env)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if name != tc.expectedName {
+					t.Errorf("Expected name %q, but got %q", tc.expectedName, name)
+				}
+				if env != tc.expectedEnv {
+					t.Errorf("Expected env %q, but got %q", tc.expectedEnv, env)
+				}
 			}
 		})
 	}
@@ -151,10 +157,16 @@ func TestGetRoleArn(t *testing.T) {
 			}
 			arn, err := client.getRoleArn(tc.roleName)
 			if tc.expectError {
-				require.Error(t, err)
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
 			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedARN, arn)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if arn != tc.expectedARN {
+					t.Errorf("Expected ARN %q, but got %q", tc.expectedARN, arn)
+				}
 			}
 		})
 	}
@@ -280,10 +292,18 @@ func TestGetTaskRole(t *testing.T) {
 			}
 			result, err := client.getTaskRole(&tc.currentRoleArn, &tc.service)
 			if tc.expectError {
-				require.Error(t, err)
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
 			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedARN, *result)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if result == nil {
+					t.Errorf("Expected result but got nil")
+				} else if *result != tc.expectedARN {
+					t.Errorf("Expected ARN %q, but got %q", tc.expectedARN, *result)
+				}
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,7 @@
 module github.com/gametimesf/ecs-deploy
 
-go 1.22
+go 1.12
 
-toolchain go1.23.4
+require github.com/aws/aws-sdk-go v1.55.2
 
-require (
-	github.com/aws/aws-sdk-go v1.55.2
-	github.com/stretchr/testify v1.10.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,11 +10,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Created this separate branch/PR to allow me to test out the change in an isolated fashion.

The purpose of this change is to ensure this won't break existing usage of this tool that have an older version of go installed that don't understand how to use the toolchain directive and break.